### PR TITLE
Chacha

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -31,7 +31,7 @@ bool_op = _{ equal | not_equal | gt | lt }
 
 bool_expr = { expr ~ bool_op ~ expr }
 if_stmt = { "if " ~ bool_expr ~ block }
-block = { "{" ~ "\n"* ~ (stmt ~ "\n")* ~ "\n"* ~ "}" }
+block = { "{" ~ "\n"* ~ ((stmt ~ "\n") | "\n")* ~ "\n"* ~ "}" }
 
 vec = { "[" ~ "\n"* ~ (vec | literal_dec) ~ "\n"* ~ ("\n"* ~ "," ~ "\n"* ~ (vec | literal_dec))* ~ "\n"* ~ "]"}
 
@@ -45,7 +45,7 @@ var_vec_def = { let_r ~ var_indexed }
 var_index_assign = { var_indexed ~ "=" ~ expr }
 
 var = { let_r? ~ varname }
-var_indexed = { varname ~ ("[" ~ atom ~ "]")+ }
+var_indexed = { varname ~ ("[" ~ expr ~ "]")+ }
 
 atom = { literal_dec | var_indexed | function_call | varname }
 

--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -10,13 +10,13 @@ fn_header = { "(" ~ ((varname ~ ("," | ")"))+ | ")") }
 stmt = { var_def | const_def | if_stmt | function_call | loop_stmt | var_index_assign | var_vec_def }
 
 expr = { atom ~ (op ~ expr)* }
-return_stmt = { "return " ~ (function_call | expr) }
+return_stmt = { "return " ~ expr }
 
 // this is distinct from fn_header because it accepts an expr or a var
-fn_args = { "(" ~ (((function_call | expr) ~ ("," | ")"))+ | ")") }
+fn_args = { "(" ~ ((expr ~ ("," | ")"))+ | ")") }
 function_call = { varname ~ fn_args }
 
-loop_stmt = { "loop" ~ (function_call | expr) ~ block }
+loop_stmt = { "loop" ~ expr ~ block }
 
 op = _{ add | sub | mul | inv }
     add = { "+" }
@@ -38,16 +38,16 @@ vec = { "[" ~ "\n"* ~ (vec | literal_dec) ~ "\n"* ~ ("\n"* ~ "," ~ "\n"* ~ (vec 
 // this let_r match is needed to
 // determine if a variable is being
 // declared for the first time
-var_def = { var ~ "=" ~ (function_call | expr | vec) }
+var_def = { var ~ "=" ~ (expr | vec) }
 let_r = { "let " }
 const_def = { "const " ~ varname ~ "=" ~ (expr | vec) }
 var_vec_def = { let_r ~ var_indexed }
-var_index_assign = { var_indexed ~ "=" ~ (function_call | expr ) }
+var_index_assign = { var_indexed ~ "=" ~ expr }
 
 var = { let_r? ~ varname }
 var_indexed = { varname ~ ("[" ~ atom ~ "]")+ }
 
-atom = { literal_dec | var_indexed | varname }
+atom = { literal_dec | var_indexed | function_call | varname }
 
 literal_dec = @{ ASCII_DIGIT+ }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -329,6 +329,7 @@ impl AshParser {
                 let mut pair = pair.into_inner();
                 let n = AshParser::next_or_error(&mut pair)?;
                 match n.as_rule() {
+                    Rule::function_call => Ok(self.build_expr_from_pair(n)?),
                     Rule::varname => Ok(Expr::Val(n.as_str().to_string(), vec![])),
                     Rule::var_indexed => {
                         let mut pair = n.into_inner();

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -555,7 +555,14 @@ impl<'a> VM<'a> {
     }
 
     // output a single stack element
-    pub fn calc_vec_offset(&mut self, _dimensions: &Vec<usize>, indices: &Vec<Expr>) {
+    pub fn calc_vec_offset(&mut self, dimensions: &Vec<usize>, indices: &Vec<Expr>) {
+        let sum = |vec: &Vec<usize>, start: usize| -> usize {
+            let mut out = 0;
+            for x in start..vec.len() {
+                out += vec[x];
+            }
+            out
+        };
         // if all values are literals we can calculate statically and push that to the stack
         let mut is_static = true;
         for i in indices {
@@ -568,17 +575,28 @@ impl<'a> VM<'a> {
             }
         }
         if is_static {
-            let offset = Self::calc_vec_offset_static(_dimensions, indices);
+            let offset = Self::calc_vec_offset_static(dimensions, indices);
             self.stack.push("vec_offset".to_string());
             self.asm.push(format!("push {offset}"));
             return;
         }
-        if indices.len() != 1 {
-            log::error!("only single dimension literal indices are allowed");
-        }
-        let o = self.eval(indices[0].clone(), false);
-        if o.is_some() {
-            log::error!("memory variables are not allowed as indices");
+        self.asm.push("push 0".to_string());
+        self.stack.push("offset".to_string());
+        for x in 0..indices.len() {
+            let o = self.eval(indices[x].clone(), false);
+            if o.is_some() {
+                log::error!("memory variables are not allowed as indices");
+            }
+            let dim_sum = sum(dimensions, x + 1);
+            if x == indices.len() - 1 && indices.len() == dimensions.len() {
+                self.asm.push("add".to_string());
+                self.stack.pop();
+            } else {
+                self.asm.push(format!("push {dim_sum}"));
+                self.asm.push("mul".to_string());
+                self.asm.push("add".to_string());
+                self.stack.pop();
+            }
         }
     }
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -557,9 +557,9 @@ impl<'a> VM<'a> {
     // output a single stack element
     pub fn calc_vec_offset(&mut self, dimensions: &Vec<usize>, indices: &Vec<Expr>) {
         let sum = |vec: &Vec<usize>, start: usize| -> usize {
-            let mut out = 0;
+            let mut out = 1;
             for x in start..vec.len() {
-                out += vec[x];
+                out *= vec[x];
             }
             out
         };
@@ -587,11 +587,11 @@ impl<'a> VM<'a> {
             if o.is_some() {
                 log::error!("memory variables are not allowed as indices");
             }
-            let dim_sum = sum(dimensions, x + 1);
             if x == indices.len() - 1 && indices.len() == dimensions.len() {
                 self.asm.push("add".to_string());
                 self.stack.pop();
             } else {
+                let dim_sum = sum(dimensions, x + 1);
                 self.asm.push(format!("push {dim_sum}"));
                 self.asm.push("mul".to_string());
                 self.asm.push("add".to_string());
@@ -602,9 +602,9 @@ impl<'a> VM<'a> {
 
     pub fn calc_vec_offset_static(dimensions: &Vec<usize>, indices: &Vec<Expr>) -> usize {
         let sum = |vec: &Vec<usize>, start: usize| -> usize {
-            let mut out = 0;
+            let mut out = 1;
             for x in start..vec.len() {
-                out += vec[x];
+                out *= vec[x];
             }
             out
         };

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -1147,7 +1147,7 @@ impl<'a> VM<'a> {
                             self.asm
                                 .push(format!("dup {}", self.stack.len() - stack_index));
                             self.asm.push("add".to_string());
-                            self.asm.push(format!("read_mem 1"));
+                            self.asm.push(format!("write_mem 1"));
                             self.asm.push(format!("pop 1"));
                             self.stack.pop();
                             self.stack.pop();

--- a/stdlib/chacha/chacha.ash
+++ b/stdlib/chacha/chacha.ash
@@ -8,27 +8,27 @@
 # the state is stored as a 16x1 matrix
 # so that individual entries can be passed
 # by reference (pointer) instead of by value
-let state[16]
+let state[16][1]
 let i = 0
 
 # nothing up my sleeve numbers
-state[0] = 1634760805
-state[1] = 857760878
-state[2] = 2036477234
-state[3] = 1797285236
+state[0][0] = 1634760805
+state[1][0] = 857760878
+state[2][0] = 2036477234
+state[3][0] = 1797285236
 
 # key values
 i = 0
 loop 8 {
-  state[4 + i] = key[i]
+  state[4 + i][0] = key[i][0]
   i = i + 1
 }
 # counter
-state[12] = lower32(counter)
-state[13] = upper32(counter)
+state[12][0] = lower32(counter)
+state[13][0] = upper32(counter)
 # nonce
-state[14] = lower32(nonce)
-state[15] = upper32(nonce)
+state[14][0] = lower32(nonce)
+state[15][0] = upper32(nonce)
 
 loop 10 {
   # odd rounds
@@ -46,6 +46,6 @@ loop 10 {
 
 i = 0
 loop 16 {
-  block[i] = state[i] + block[i]
+  block[i][0] = state[i][0] + block[i][0]
   i = i + 1
 }

--- a/stdlib/chacha/chacha.ash
+++ b/stdlib/chacha/chacha.ash
@@ -8,27 +8,27 @@
 # the state is stored as a 16x1 matrix
 # so that individual entries can be passed
 # by reference (pointer) instead of by value
-let state[16][1]
-let i
+let state[16]
+let i = 0
 
 # nothing up my sleeve numbers
-state[0][0] = 1634760805
-state[1][0] = 857760878
-state[2][0] = 2036477234
-state[3][0] = 1797285236
+state[0] = 1634760805
+state[1] = 857760878
+state[2] = 2036477234
+state[3] = 1797285236
 
 # key values
 i = 0
 loop 8 {
-  state[4 + i][0] = key[i]
+  state[4 + i] = key[i]
   i = i + 1
 }
 # counter
-state[12][0] = lower32(counter)
-state[13][0] = upper32(counter)
+state[12] = lower32(counter)
+state[13] = upper32(counter)
 # nonce
-state[14][0] = lower32(nonce)
-state[15][0] = upper32(nonce)
+state[14] = lower32(nonce)
+state[15] = upper32(nonce)
 
 loop 10 {
   # odd rounds
@@ -46,6 +46,6 @@ loop 10 {
 
 i = 0
 loop 16 {
-  block[i] = state[i][0] + block[i]
+  block[i] = state[i] + block[i]
   i = i + 1
 }

--- a/stdlib/chacha/chacha.ash
+++ b/stdlib/chacha/chacha.ash
@@ -1,0 +1,51 @@
+# the chacha state contains 4 32 bit constant words
+# 8 32 bit key words
+# 2 32 bit counter words indicating the position in the stream
+# 2 32 bit nonce words that must never be repeated
+# the block input will be overwritten
+(key, counter, nonce, block)
+
+# the state is stored as a 16x1 matrix
+# so that individual entries can be passed
+# by reference (pointer) instead of by value
+let state[16][1]
+let i
+
+# nothing up my sleeve numbers
+state[0][0] = 1634760805
+state[1][0] = 857760878
+state[2][0] = 2036477234
+state[3][0] = 1797285236
+
+# key values
+i = 0
+loop 8 {
+  state[4 + i][0] = key[i]
+  i = i + 1
+}
+# counter
+state[12][0] = lower32(counter)
+state[13][0] = upper32(counter)
+# nonce
+state[14][0] = lower32(nonce)
+state[15][0] = upper32(nonce)
+
+loop 10 {
+  # odd rounds
+  chacha_quarter(state[0], state[4], state[8], state[12])
+  chacha_quarter(state[1], state[5], state[9], state[13])
+  chacha_quarter(state[2], state[6], state[10], state[14])
+  chacha_quarter(state[3], state[7], state[11], state[15])
+
+  # even rounds
+  chacha_quarter(state[0], state[5], state[10], state[15])
+  chacha_quarter(state[1], state[6], state[11], state[12])
+  chacha_quarter(state[2], state[7], state[8], state[13])
+  chacha_quarter(state[3], state[4], state[9], state[14])
+}
+
+i = 0
+loop 16 {
+  block[i] = state[i][0] + block[i]
+  i = i + 1
+}

--- a/stdlib/chacha/chacha_quarter.ash
+++ b/stdlib/chacha/chacha_quarter.ash
@@ -4,10 +4,10 @@
 # c += d; b ^= c; b <<<= 12;
 # a += b; d ^= a; d <<<=  8;
 # c += d; b ^= c; b <<<=  7;
-let a = am
-let b = bm
-let c = cm
-let d = dm
+let a = am[0]
+let b = bm[0]
+let c = cm[0]
+let d = dm[0]
 
 a = lower32(a + b)
 d = shlc(xor(a, d), 16)
@@ -20,3 +20,8 @@ d = shlc(xor(a, d), 8)
 
 c = lower32(c + d)
 b = shlc(xor(b, c), 7)
+
+am[0] = a
+bm[0] = b
+cm[0] = c
+dm[0] = d

--- a/stdlib/chacha/chacha_quarter.ash
+++ b/stdlib/chacha/chacha_quarter.ash
@@ -4,24 +4,19 @@
 # c += d; b ^= c; b <<<= 12;
 # a += b; d ^= a; d <<<=  8;
 # c += d; b ^= c; b <<<=  7;
-let a = am[0]
-let b = bm[0]
-let c = cm[0]
-let c = dm[0]
+let a = am
+let b = bm
+let c = cm
+let d = dm
 
-a = a + b
+a = lower32(a + b)
 d = shlc(xor(a, d), 16)
 
-c = c + d
+c = lower32(c + d)
 b = shlc(xor(b, c), 12)
 
-a = a + b
+a = lower32(a + b)
 d = shlc(xor(a, d), 8)
 
-c = c + d
+c = lower32(c + d)
 b = shlc(xor(b, c), 7)
-
-am[0] = a
-bm[0] = b
-cm[0] = c
-dm[0] = d

--- a/stdlib/chacha/chacha_quarter.ash
+++ b/stdlib/chacha/chacha_quarter.ash
@@ -1,0 +1,27 @@
+(am, bm, cm, dm)
+
+# a += b; d ^= a; d <<<= 16;
+# c += d; b ^= c; b <<<= 12;
+# a += b; d ^= a; d <<<=  8;
+# c += d; b ^= c; b <<<=  7;
+let a = am[0]
+let b = bm[0]
+let c = cm[0]
+let c = dm[0]
+
+a = a + b
+d = shlc(xor(a, d), 16)
+
+c = c + d
+b = shlc(xor(b, c), 12)
+
+a = a + b
+d = shlc(xor(a, d), 8)
+
+c = c + d
+b = shlc(xor(b, c), 7)
+
+am[0] = a
+bm[0] = b
+cm[0] = c
+dm[0] = d

--- a/test-vectors/chacha_test.ash
+++ b/test-vectors/chacha_test.ash
@@ -1,0 +1,8 @@
+let i = 0
+
+let state[16] # test
+
+loop 16 {
+  state[add(0, i)] = i
+  i = i + 1
+}

--- a/test-vectors/chacha_test.ash
+++ b/test-vectors/chacha_test.ash
@@ -1,10 +1,10 @@
 let i = 0
 
-let state[16] # test
+let state[16][1] # test
 
-loop 16 {
-  state[add(0, i)] = i
-  i = i + 1
-}
+#loop 16 {
+  #state[add(0, i)][0] = i
+  #i = i + 1
+#}
 
 chacha(state, 0, 0, state)

--- a/test-vectors/chacha_test.ash
+++ b/test-vectors/chacha_test.ash
@@ -6,3 +6,5 @@ loop 16 {
   state[add(0, i)] = i
   i = i + 1
 }
+
+chacha(state, 0, 0, state)

--- a/test-vectors/vec_assign_test.ash
+++ b/test-vectors/vec_assign_test.ash
@@ -1,39 +1,51 @@
-let vec[2][3]
-vec[0][0] = 99
-vec[1][2] = 999
 
-assert_eq(vec[0][0], 99)
-assert_eq(vec[1][2], 999)
+let high_dim[10][10][10][10][10]
 
-let vec2[2][3]
-vec2[0][0] = 99
-vec2[1][2] = 999
 
-assert_eq(vec2[0][0], 99)
-assert_eq(vec2[1][2], 999)
-
-let vec_dyn[100]
 let i = 0
-loop 100 {
-  vec_dyn[i] = i
+let j = 0
+let k = 0
+let l = 0
+let m = 0
+loop 4 {
+  j = 0
+  loop 4 {
+    k = 0
+    loop 4 {
+      l = 0
+      loop 4 {
+        m = 0
+        loop 4 {
+          high_dim[i][j][k][l][m] = i * j * k * l * m
+          m = m + 1
+        }
+        l = l + 1
+      }
+      k = k + 1
+    }
+    j = j + 1
+  }
   i = i + 1
 }
 
-i = 0
-loop 100 {
-  assert_eq(vec_dyn[i], i)
-  i = i + 1
-}
+assert_eq(high_dim[0][0][0][0][0], 0)
+assert_eq(high_dim[1][1][1][1][1], 1)
+assert_eq(high_dim[2][2][2][2][2], 32)
+assert_eq(high_dim[3][3][3][3][3], 243)
+assert_eq(high_dim[3][3][1][3][3], 81)
 
-let vec_dyn2[100]
-vec_dyn2[vec_dyn[5]] = 99
-assert_eq(vec_dyn2[5], 99)
-assert_eq(vec_dyn2[vec_dyn[5]], 99)
+i = 3
+j = 3
+k = 2
+l = 3
+m = 1
+assert_eq(high_dim[i][j][k][l][m], 54)
+assert_eq(high_dim[i][j][k][l][m], i * j * k * l * m)
 
-# test expr in function call
-assert_eq(vec_dyn[5] * vec_dyn[5], 25)
-# test expr in assignment
-let x = vec_dyn[5] * vec_dyn[5]
-assert_eq(x, 25)
-
-vec_dyn[5] = 99
+i = 1
+j = 2
+k = 2
+l = 3
+m = 1
+assert_eq(high_dim[i][j][k][l][m], 12)
+assert_eq(high_dim[i][j][k][l][m], i * j * k * l * m)


### PR DESCRIPTION
Moves `function_call` clause into `expr` to allow function calls anywhere an expr is allowed.
Allow variable indices of any dimension.