### PR TITLE
feat: basic r1cs compilation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,19 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-  compile-and-prove:
+  compile-r1cs:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.79.0
+          override: true
+      - name: Run test vectors
+        run: cargo run --release -- r1cs_test -t r1cs -i ./test-vectors -v
+  compile-tasm:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -215,7 +215,20 @@ impl Compiler {
         }
         match target {
             "r1cs" => {
-                log::error!("r1cs compile target is not yet supported");
+                let mut vm = crate::r1cs::vm::VM::new(&mut self.state);
+                // build constraints from the AST
+                vm.eval_ast(parser.ast);
+                if self.print_asm {
+                    // prints the raw constraints
+                    for c in &vm.constraints {
+                        println!("{}", c.to_string());
+                    }
+                }
+                vm.constraints
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<String>>()
+                    .join("\n")
             }
             "tasm" => {
                 // step 1: compile the entrypoint to assembly

--- a/src/r1cs/inv.rs
+++ b/src/r1cs/inv.rs
@@ -1,0 +1,23 @@
+// temporary implementation until we switch
+// to a proper number library
+pub fn inv(v: u64, m: u64) -> u64 {
+    let v = v % m;
+    if v == 0 {
+        panic!("divide by zero");
+    }
+    let mut y = 0_u128;
+    let mut x = 1_u128;
+    let mut f = u128::try_from(m).unwrap();
+    let mut v = u128::try_from(v).unwrap();
+    let m = u128::try_from(m).unwrap();
+    while v > 1 {
+        let q = v / f;
+        let mut t = f;
+        f = v % f;
+        v = t;
+        t = y;
+        y = x - q * y;
+        x = t;
+    }
+    return u64::try_from(x % m).unwrap();
+}

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -1,0 +1,1 @@
+pub mod vm;

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -1,1 +1,2 @@
+mod inv;
 pub mod vm;

--- a/src/r1cs/vm.rs
+++ b/src/r1cs/vm.rs
@@ -1,0 +1,190 @@
+use crate::{
+    compiler::CompilerState,
+    log,
+    parser::{AstNode, Expr, Op},
+};
+use std::collections::HashMap;
+
+// a b and c represent values in
+// a constraint a * b - c = 0
+// each factor specifies an array
+// of coefficient, index pairs
+// indices may be specified multiple times
+// and will be summed
+pub struct R1csConstraint {
+    // (coefficient, var_index)
+    pub a: Vec<(u64, u64)>,
+    pub b: Vec<(u64, u64)>,
+    pub c: Vec<(u64, u64)>,
+}
+
+impl ToString for R1csConstraint {
+    fn to_string(&self) -> String {
+        let mut out = "".to_owned();
+        out.push_str("[");
+        for (coef, index) in &self.a {
+            out.push_str(&format!("({},{})", coef, index));
+        }
+        out.push_str("][");
+        for (coef, index) in &self.b {
+            out.push_str(&format!("({},{})", coef, index));
+        }
+        out.push_str("][");
+        for (coef, index) in &self.c {
+            out.push_str(&format!("({},{})", coef, index));
+        }
+        out.push_str("]");
+        out
+    }
+}
+
+pub struct VM<'a> {
+    pub prime: u64,
+    // global counter for distinct variables
+    // variable at index 0 is always 1
+    pub var_index: u64,
+    // local scope name keyed to global variable index
+    pub vars: HashMap<String, u64>,
+    pub compiler_state: &'a mut CompilerState,
+    // a, b, c
+    pub constraints: Vec<R1csConstraint>,
+}
+
+impl<'a> VM<'a> {
+    pub fn new(compiler_state: &'a mut CompilerState) -> Self {
+        VM {
+            prime: 18446744069414584321, // 0xfoi
+            var_index: 1,
+            vars: HashMap::new(),
+            compiler_state,
+            constraints: Vec::new(),
+        }
+    }
+
+    pub fn eval(&mut self, expr: Expr) -> u64 {
+        match &expr {
+            Expr::VecLit(_v) => {
+                panic!("vector literals must be assigned before operation");
+            }
+            Expr::VecVec(_v) => {
+                panic!("matrix literals must be assigned before operation");
+            }
+            Expr::FnCall(name, vars) => {
+                log::error!(&format!("function calls not supported in r1cs: {name}"));
+            }
+            Expr::Val(name, indices) => {
+                if indices.len() > 0 {
+                    log::error!(
+                        "indices not supported in r1cs, accessing indices on variable: {name}"
+                    );
+                }
+                if let Some(v) = self.vars.get(name) {
+                    return v.clone();
+                } else {
+                    log::error!("variable not found: {name}");
+                }
+            }
+            Expr::NumOp { lhs, op, rhs } => {
+                let lv = self.eval(*lhs.clone());
+                let rv = self.eval(*rhs.clone());
+                match op {
+                    Op::Add => {
+                        let new_var = self.var_index;
+                        self.var_index += 1;
+                        // (1*lv + 1*rv) * (1*1) - (1*new_var) = 0
+                        // lv + rv - new_var = 0
+                        self.constraints.push(R1csConstraint {
+                            a: vec![(1, lv), (1, rv)],
+                            b: vec![(1, 0)],
+                            c: vec![(1, new_var)],
+                        });
+                        return new_var;
+                    }
+                    Op::Mul => {
+                        let new_var = self.var_index;
+                        self.var_index += 1;
+                        // (1*lv) * (1*rv) - (1*new_var) = 0
+                        // lv * rv - new_var = 0
+                        self.constraints.push(R1csConstraint {
+                            a: vec![(1, lv)],
+                            b: vec![(1, rv)],
+                            c: vec![(1, new_var)],
+                        });
+                        return new_var;
+                    }
+                    Op::Sub => {
+                        let new_var = self.var_index;
+                        self.var_index += 1;
+                        // (1*lv + -1*rv) * (1*1) - (1*new_var) = 0
+                        // lv + -1*rv - new_var = 0
+                        self.constraints.push(R1csConstraint {
+                            a: vec![(1, lv), (self.prime - 1, rv)],
+                            b: vec![(1, 0)],
+                            c: vec![(1, new_var)],
+                        });
+                        return new_var;
+                    }
+                    Op::Inv => {
+                        // (1/rhs) * lhs
+                        //
+                        let rhs_inv = self.var_index;
+                        self.var_index += 1;
+                        // first: constrain rhs_inv
+                        // (1*rhs) * (1*rhs_inv) - (1*1) = 0
+                        // rhs * rhs_inv - 1 = 0
+                        self.constraints.push(R1csConstraint {
+                            a: vec![(1, lv)],
+                            b: vec![(1, rhs_inv)],
+                            c: vec![(1, 0)],
+                        });
+                        let new_var = self.var_index;
+                        self.var_index += 1;
+                        // second: constrain the inv multiplication
+                        // (1*lhs) * (1*rhs_inv) - (1*new_var) = 0
+                        self.constraints.push(R1csConstraint {
+                            a: vec![(1, lv)],
+                            b: vec![(1, rhs_inv)],
+                            c: vec![(1, new_var)],
+                        });
+                        return new_var;
+                    }
+                }
+            }
+            Expr::Lit(val) => {
+                let new_var = self.var_index;
+                self.var_index += 1;
+                self.constraints.push(R1csConstraint {
+                    a: vec![(1, new_var)],
+                    b: vec![(1, 0)],
+                    c: vec![(val.clone(), 0)],
+                });
+                new_var
+            }
+            _ => {
+                log::error!("unimplemented expression case");
+            }
+        }
+    }
+
+    pub fn eval_ast(&mut self, ast: Vec<AstNode>) {
+        for v in ast {
+            match v {
+                AstNode::Stmt(name, is_let, expr) => {
+                    if !is_let {
+                        log::error!("re-assignment not supported");
+                    }
+                    if self.vars.contains_key(&name) {
+                        log::error!("variable already defined: {name}");
+                    }
+                    // returns a variable index
+                    let v = self.eval(expr);
+                    self.vars.insert(name, v);
+                }
+                AstNode::Const(name, expr) => {}
+                _ => {
+                    log::error!(&format!("ast node not supported for r1cs: {:?}", v));
+                }
+            }
+        }
+    }
+}

--- a/src/r1cs/vm.rs
+++ b/src/r1cs/vm.rs
@@ -13,9 +13,23 @@ use std::collections::HashMap;
 // and will be summed
 pub struct R1csConstraint {
     // (coefficient, var_index)
-    pub a: Vec<(u64, u64)>,
-    pub b: Vec<(u64, u64)>,
-    pub c: Vec<(u64, u64)>,
+    pub a: Vec<(u64, usize)>,
+    pub b: Vec<(u64, usize)>,
+    pub c: Vec<(u64, usize)>,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum VarLocation {
+    Static,
+    Constraint,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Var {
+    index: usize,
+    location: VarLocation,
+    dimensions: Vec<usize>,
+    value: Vec<u64>,
 }
 
 impl ToString for R1csConstraint {
@@ -42,9 +56,9 @@ pub struct VM<'a> {
     pub prime: u64,
     // global counter for distinct variables
     // variable at index 0 is always 1
-    pub var_index: u64,
+    pub var_index: usize,
     // local scope name keyed to global variable index
-    pub vars: HashMap<String, u64>,
+    pub vars: HashMap<String, Var>,
     pub compiler_state: &'a mut CompilerState,
     // a, b, c
     pub constraints: Vec<R1csConstraint>,
@@ -61,7 +75,7 @@ impl<'a> VM<'a> {
         }
     }
 
-    pub fn eval(&mut self, expr: Expr) -> u64 {
+    pub fn eval(&mut self, expr: Expr) -> Var {
         match &expr {
             Expr::VecLit(_v) => {
                 panic!("vector literals must be assigned before operation");
@@ -87,74 +101,184 @@ impl<'a> VM<'a> {
             Expr::NumOp { lhs, op, rhs } => {
                 let lv = self.eval(*lhs.clone());
                 let rv = self.eval(*rhs.clone());
+                if lv.location != VarLocation::Constraint {
+                    log::error!(&format!("lhs is not a constraint variable: {:?}", lhs));
+                }
+                if rv.location != VarLocation::Constraint {
+                    log::error!(&format!("rhs is not a constraint variable: {:?}", rhs));
+                }
+                if rv.dimensions.len() != lv.dimensions.len() {
+                    log::error!(&format!(
+                        "lhs and rhs dimensions are not equal: {:?} {:?}",
+                        lhs, rhs
+                    ));
+                }
+                for x in 0..rv.dimensions.len() {
+                    if rv.dimensions[x] != lv.dimensions[x] {
+                        log::error!(&format!(
+                            "lhs and rhs inner dimensions are not equal: {:?} {:?}",
+                            lhs, rhs
+                        ));
+                    }
+                }
+                // take a lhs and rhs of variable size and apply
+                // an operation to each element
+                let mut operate = |lhs: Var,
+                                   rhs: Var,
+                                   op: Box<
+                    dyn Fn(u64, u64, usize, usize, usize) -> (Vec<R1csConstraint>, u64),
+                >|
+                 -> Var {
+                    let mut new_var = Var {
+                        index: self.var_index,
+                        location: VarLocation::Constraint,
+                        dimensions: lhs.dimensions.clone(),
+                        value: vec![],
+                    };
+                    self.var_index += lhs.value.len();
+                    for x in 0..lhs.value.len() {
+                        // will generate constraints and output value
+                        let (constraints, val) = (*op)(
+                            lhs.value[x],
+                            rhs.value[x],
+                            lhs.index + x,
+                            rhs.index + x,
+                            new_var.index + x,
+                        );
+                        new_var.value.push(val);
+                        for c in constraints {
+                            self.constraints.push(c);
+                        }
+                    }
+                    new_var
+                };
+                // TODO: better field math
                 match op {
                     Op::Add => {
-                        let new_var = self.var_index;
-                        self.var_index += 1;
-                        // (1*lv + 1*rv) * (1*1) - (1*new_var) = 0
-                        // lv + rv - new_var = 0
-                        self.constraints.push(R1csConstraint {
-                            a: vec![(1, lv), (1, rv)],
-                            b: vec![(1, 0)],
-                            c: vec![(1, new_var)],
-                        });
-                        return new_var;
+                        let add = |a: u64,
+                                   b: u64,
+                                   ai: usize,
+                                   bi: usize,
+                                   oi: usize|
+                         -> (Vec<R1csConstraint>, u64) {
+                            let x = (u128::try_from(a).unwrap() + u128::try_from(b).unwrap())
+                                % u128::try_from(self.prime).unwrap();
+                            // (1*lv + 1*rv) * (1*1) - (1*new_var) = 0
+                            // lv + rv - new_var = 0
+                            (
+                                vec![R1csConstraint {
+                                    a: vec![(1, ai), (1, bi)],
+                                    b: vec![(1, 0)],
+                                    c: vec![(1, oi)],
+                                }],
+                                u64::try_from(x).unwrap(),
+                            )
+                        };
+                        operate(lv, rv, Box::new(add))
                     }
                     Op::Mul => {
-                        let new_var = self.var_index;
-                        self.var_index += 1;
-                        // (1*lv) * (1*rv) - (1*new_var) = 0
-                        // lv * rv - new_var = 0
-                        self.constraints.push(R1csConstraint {
-                            a: vec![(1, lv)],
-                            b: vec![(1, rv)],
-                            c: vec![(1, new_var)],
-                        });
-                        return new_var;
+                        let mul = |a: u64,
+                                   b: u64,
+                                   ai: usize,
+                                   bi: usize,
+                                   oi: usize|
+                         -> (Vec<R1csConstraint>, u64) {
+                            let x = (u128::try_from(a).unwrap() * u128::try_from(b).unwrap())
+                                % u128::try_from(self.prime).unwrap();
+                            // (1*lv) * (1*rv) - (1*new_var) = 0
+                            // lv * rv - new_var = 0
+                            (
+                                vec![R1csConstraint {
+                                    a: vec![(1, ai)],
+                                    b: vec![(1, bi)],
+                                    c: vec![(1, oi)],
+                                }],
+                                u64::try_from(x).unwrap(),
+                            )
+                        };
+                        operate(lv, rv, Box::new(mul))
                     }
                     Op::Sub => {
-                        let new_var = self.var_index;
-                        self.var_index += 1;
-                        // (1*lv + -1*rv) * (1*1) - (1*new_var) = 0
-                        // lv + -1*rv - new_var = 0
-                        self.constraints.push(R1csConstraint {
-                            a: vec![(1, lv), (self.prime - 1, rv)],
-                            b: vec![(1, 0)],
-                            c: vec![(1, new_var)],
-                        });
-                        return new_var;
+                        let sub = |a: u64,
+                                   b: u64,
+                                   ai: usize,
+                                   bi: usize,
+                                   oi: usize|
+                         -> (Vec<R1csConstraint>, u64) {
+                            let x = (u128::try_from(self.prime - 1).unwrap()
+                                + u128::try_from(a).unwrap()
+                                - u128::try_from(b).unwrap())
+                                % u128::try_from(self.prime).unwrap();
+                            // (1*lv + -1*rv) * (1*1) - (1*new_var) = 0
+                            // lv + -1*rv - new_var = 0
+                            (
+                                vec![R1csConstraint {
+                                    a: vec![(1, ai), (self.prime - 1, bi)],
+                                    b: vec![(1, 0)],
+                                    c: vec![(1, oi)],
+                                }],
+                                u64::try_from(x).unwrap(),
+                            )
+                        };
+                        operate(lv, rv, Box::new(sub))
                     }
                     Op::Inv => {
                         // (1/rhs) * lhs
-                        //
-                        let rhs_inv = self.var_index;
-                        self.var_index += 1;
-                        // first: constrain rhs_inv
-                        // (1*rhs) * (1*rhs_inv) - (1*1) = 0
-                        // rhs * rhs_inv - 1 = 0
-                        self.constraints.push(R1csConstraint {
-                            a: vec![(1, lv)],
-                            b: vec![(1, rhs_inv)],
-                            c: vec![(1, 0)],
-                        });
-                        let new_var = self.var_index;
-                        self.var_index += 1;
-                        // second: constrain the inv multiplication
-                        // (1*lhs) * (1*rhs_inv) - (1*new_var) = 0
-                        self.constraints.push(R1csConstraint {
-                            a: vec![(1, lv)],
-                            b: vec![(1, rhs_inv)],
-                            c: vec![(1, new_var)],
-                        });
-                        return new_var;
+                        // first invert the rhs and store in a variable
+                        let inv = |_: u64,
+                                   b: u64,
+                                   _: usize,
+                                   bi: usize,
+                                   oi: usize|
+                         -> (Vec<R1csConstraint>, u64) {
+                            let b_inv = crate::r1cs::inv::inv(b, self.prime);
+                            // first: constrain rhs_inv
+                            // (1*rhs) * (1*rhs_inv) - (1*1) = 0
+                            // rhs * rhs_inv - 1 = 0
+                            (
+                                vec![R1csConstraint {
+                                    a: vec![(1, bi)],
+                                    b: vec![(1, oi)],
+                                    c: vec![(1, 0)],
+                                }],
+                                u64::try_from(b_inv).unwrap(),
+                            )
+                        };
+                        let rv_inv = operate(rv.clone(), rv.clone(), Box::new(inv));
+                        // then multiple rv_inv by the lhs
+                        let mul = |a: u64,
+                                   b: u64,
+                                   ai: usize,
+                                   bi: usize,
+                                   oi: usize|
+                         -> (Vec<R1csConstraint>, u64) {
+                            let x = (u128::try_from(a).unwrap() * u128::try_from(b).unwrap())
+                                % u128::try_from(self.prime).unwrap();
+                            // (1*lv) * (1*rv) - (1*new_var) = 0
+                            // lv * rv - new_var = 0
+                            (
+                                vec![R1csConstraint {
+                                    a: vec![(1, ai)],
+                                    b: vec![(1, bi)],
+                                    c: vec![(1, oi)],
+                                }],
+                                u64::try_from(x).unwrap(),
+                            )
+                        };
+                        operate(lv, rv_inv, Box::new(mul))
                     }
                 }
             }
             Expr::Lit(val) => {
-                let new_var = self.var_index;
+                let new_var = Var {
+                    index: self.var_index,
+                    location: VarLocation::Constraint,
+                    dimensions: vec![],
+                    value: vec![*val],
+                };
                 self.var_index += 1;
                 self.constraints.push(R1csConstraint {
-                    a: vec![(1, new_var)],
+                    a: vec![(1, new_var.index)],
                     b: vec![(1, 0)],
                     c: vec![(val.clone(), 0)],
                 });

--- a/src/r1cs/vm.rs
+++ b/src/r1cs/vm.rs
@@ -1,7 +1,7 @@
 use crate::{
     compiler::CompilerState,
     log,
-    parser::{AstNode, Expr, Op},
+    parser::{AstNode, Expr, NumOp},
 };
 use std::collections::HashMap;
 
@@ -142,7 +142,7 @@ impl<'a> VM<'a> {
         }
     }
 
-    fn eval_numop(&mut self, lhs: &Expr, op: &Op, rhs: &Expr) -> Var {
+    fn eval_numop(&mut self, lhs: &Expr, op: &NumOp, rhs: &Expr) -> Var {
         let lv = self.eval(lhs);
         let rv = self.eval(rhs);
         if lv.location != VarLocation::Constraint {
@@ -197,7 +197,7 @@ impl<'a> VM<'a> {
             };
         // TODO: better field math
         match op {
-            Op::Add => {
+            NumOp::Add => {
                 let add = |a: u64,
                            b: u64,
                            ai: usize,
@@ -219,7 +219,7 @@ impl<'a> VM<'a> {
                 };
                 operate(lv, rv, Box::new(add))
             }
-            Op::Mul => {
+            NumOp::Mul => {
                 let mul = |a: u64,
                            b: u64,
                            ai: usize,
@@ -241,7 +241,7 @@ impl<'a> VM<'a> {
                 };
                 operate(lv, rv, Box::new(mul))
             }
-            Op::Sub => {
+            NumOp::Sub => {
                 let sub = |a: u64,
                            b: u64,
                            ai: usize,
@@ -264,7 +264,7 @@ impl<'a> VM<'a> {
                 };
                 operate(lv, rv, Box::new(sub))
             }
-            Op::Inv => {
+            NumOp::Inv => {
                 // (1/rhs) * lhs
                 // first invert the rhs and store in a variable
                 let inv = |_: u64,

--- a/src/r1cs/vm.rs
+++ b/src/r1cs/vm.rs
@@ -75,7 +75,29 @@ impl<'a> VM<'a> {
         }
     }
 
-    pub fn eval(&mut self, expr: Expr) -> Var {
+    pub fn eval_ast(&mut self, ast: Vec<AstNode>) {
+        for v in ast {
+            match v {
+                AstNode::Stmt(name, is_let, expr) => {
+                    if !is_let {
+                        log::error!("re-assignment not supported");
+                    }
+                    if self.vars.contains_key(&name) {
+                        log::error!("variable already defined: {name}");
+                    }
+                    // returns a variable index
+                    let v = self.eval(&expr);
+                    self.vars.insert(name, v);
+                }
+                AstNode::Const(name, expr) => {}
+                _ => {
+                    log::error!(&format!("ast node not supported for r1cs: {:?}", v));
+                }
+            }
+        }
+    }
+
+    pub fn eval(&mut self, expr: &Expr) -> Var {
         match &expr {
             Expr::VecLit(_v) => {
                 panic!("vector literals must be assigned before operation");
@@ -98,177 +120,7 @@ impl<'a> VM<'a> {
                     log::error!("variable not found: {name}");
                 }
             }
-            Expr::NumOp { lhs, op, rhs } => {
-                let lv = self.eval(*lhs.clone());
-                let rv = self.eval(*rhs.clone());
-                if lv.location != VarLocation::Constraint {
-                    log::error!(&format!("lhs is not a constraint variable: {:?}", lhs));
-                }
-                if rv.location != VarLocation::Constraint {
-                    log::error!(&format!("rhs is not a constraint variable: {:?}", rhs));
-                }
-                if rv.dimensions.len() != lv.dimensions.len() {
-                    log::error!(&format!(
-                        "lhs and rhs dimensions are not equal: {:?} {:?}",
-                        lhs, rhs
-                    ));
-                }
-                for x in 0..rv.dimensions.len() {
-                    if rv.dimensions[x] != lv.dimensions[x] {
-                        log::error!(&format!(
-                            "lhs and rhs inner dimensions are not equal: {:?} {:?}",
-                            lhs, rhs
-                        ));
-                    }
-                }
-                // take a lhs and rhs of variable size and apply
-                // an operation to each element
-                let mut operate = |lhs: Var,
-                                   rhs: Var,
-                                   op: Box<
-                    dyn Fn(u64, u64, usize, usize, usize) -> (Vec<R1csConstraint>, u64),
-                >|
-                 -> Var {
-                    let mut new_var = Var {
-                        index: self.var_index,
-                        location: VarLocation::Constraint,
-                        dimensions: lhs.dimensions.clone(),
-                        value: vec![],
-                    };
-                    self.var_index += lhs.value.len();
-                    for x in 0..lhs.value.len() {
-                        // will generate constraints and output value
-                        let (constraints, val) = (*op)(
-                            lhs.value[x],
-                            rhs.value[x],
-                            lhs.index + x,
-                            rhs.index + x,
-                            new_var.index + x,
-                        );
-                        new_var.value.push(val);
-                        for c in constraints {
-                            self.constraints.push(c);
-                        }
-                    }
-                    new_var
-                };
-                // TODO: better field math
-                match op {
-                    Op::Add => {
-                        let add = |a: u64,
-                                   b: u64,
-                                   ai: usize,
-                                   bi: usize,
-                                   oi: usize|
-                         -> (Vec<R1csConstraint>, u64) {
-                            let x = (u128::try_from(a).unwrap() + u128::try_from(b).unwrap())
-                                % u128::try_from(self.prime).unwrap();
-                            // (1*lv + 1*rv) * (1*1) - (1*new_var) = 0
-                            // lv + rv - new_var = 0
-                            (
-                                vec![R1csConstraint {
-                                    a: vec![(1, ai), (1, bi)],
-                                    b: vec![(1, 0)],
-                                    c: vec![(1, oi)],
-                                }],
-                                u64::try_from(x).unwrap(),
-                            )
-                        };
-                        operate(lv, rv, Box::new(add))
-                    }
-                    Op::Mul => {
-                        let mul = |a: u64,
-                                   b: u64,
-                                   ai: usize,
-                                   bi: usize,
-                                   oi: usize|
-                         -> (Vec<R1csConstraint>, u64) {
-                            let x = (u128::try_from(a).unwrap() * u128::try_from(b).unwrap())
-                                % u128::try_from(self.prime).unwrap();
-                            // (1*lv) * (1*rv) - (1*new_var) = 0
-                            // lv * rv - new_var = 0
-                            (
-                                vec![R1csConstraint {
-                                    a: vec![(1, ai)],
-                                    b: vec![(1, bi)],
-                                    c: vec![(1, oi)],
-                                }],
-                                u64::try_from(x).unwrap(),
-                            )
-                        };
-                        operate(lv, rv, Box::new(mul))
-                    }
-                    Op::Sub => {
-                        let sub = |a: u64,
-                                   b: u64,
-                                   ai: usize,
-                                   bi: usize,
-                                   oi: usize|
-                         -> (Vec<R1csConstraint>, u64) {
-                            let x = (u128::try_from(self.prime - 1).unwrap()
-                                + u128::try_from(a).unwrap()
-                                - u128::try_from(b).unwrap())
-                                % u128::try_from(self.prime).unwrap();
-                            // (1*lv + -1*rv) * (1*1) - (1*new_var) = 0
-                            // lv + -1*rv - new_var = 0
-                            (
-                                vec![R1csConstraint {
-                                    a: vec![(1, ai), (self.prime - 1, bi)],
-                                    b: vec![(1, 0)],
-                                    c: vec![(1, oi)],
-                                }],
-                                u64::try_from(x).unwrap(),
-                            )
-                        };
-                        operate(lv, rv, Box::new(sub))
-                    }
-                    Op::Inv => {
-                        // (1/rhs) * lhs
-                        // first invert the rhs and store in a variable
-                        let inv = |_: u64,
-                                   b: u64,
-                                   _: usize,
-                                   bi: usize,
-                                   oi: usize|
-                         -> (Vec<R1csConstraint>, u64) {
-                            let b_inv = crate::r1cs::inv::inv(b, self.prime);
-                            // first: constrain rhs_inv
-                            // (1*rhs) * (1*rhs_inv) - (1*1) = 0
-                            // rhs * rhs_inv - 1 = 0
-                            (
-                                vec![R1csConstraint {
-                                    a: vec![(1, bi)],
-                                    b: vec![(1, oi)],
-                                    c: vec![(1, 0)],
-                                }],
-                                u64::try_from(b_inv).unwrap(),
-                            )
-                        };
-                        let rv_inv = operate(rv.clone(), rv.clone(), Box::new(inv));
-                        // then multiple rv_inv by the lhs
-                        let mul = |a: u64,
-                                   b: u64,
-                                   ai: usize,
-                                   bi: usize,
-                                   oi: usize|
-                         -> (Vec<R1csConstraint>, u64) {
-                            let x = (u128::try_from(a).unwrap() * u128::try_from(b).unwrap())
-                                % u128::try_from(self.prime).unwrap();
-                            // (1*lv) * (1*rv) - (1*new_var) = 0
-                            // lv * rv - new_var = 0
-                            (
-                                vec![R1csConstraint {
-                                    a: vec![(1, ai)],
-                                    b: vec![(1, bi)],
-                                    c: vec![(1, oi)],
-                                }],
-                                u64::try_from(x).unwrap(),
-                            )
-                        };
-                        operate(lv, rv_inv, Box::new(mul))
-                    }
-                }
-            }
+            Expr::NumOp { lhs, op, rhs } => self.eval_numop(&*lhs, op, &*rhs),
             Expr::Lit(val) => {
                 let new_var = Var {
                     index: self.var_index,
@@ -290,24 +142,172 @@ impl<'a> VM<'a> {
         }
     }
 
-    pub fn eval_ast(&mut self, ast: Vec<AstNode>) {
-        for v in ast {
-            match v {
-                AstNode::Stmt(name, is_let, expr) => {
-                    if !is_let {
-                        log::error!("re-assignment not supported");
+    fn eval_numop(&mut self, lhs: &Expr, op: &Op, rhs: &Expr) -> Var {
+        let lv = self.eval(lhs);
+        let rv = self.eval(rhs);
+        if lv.location != VarLocation::Constraint {
+            log::error!(&format!("lhs is not a constraint variable: {:?}", lhs));
+        }
+        if rv.location != VarLocation::Constraint {
+            log::error!(&format!("rhs is not a constraint variable: {:?}", rhs));
+        }
+        if rv.dimensions.len() != lv.dimensions.len() {
+            log::error!(&format!(
+                "lhs and rhs dimensions are not equal: {:?} {:?}",
+                lhs, rhs
+            ));
+        }
+        for x in 0..rv.dimensions.len() {
+            if rv.dimensions[x] != lv.dimensions[x] {
+                log::error!(&format!(
+                    "lhs and rhs inner dimensions are not equal: {:?} {:?}",
+                    lhs, rhs
+                ));
+            }
+        }
+        // take a lhs and rhs of variable size and apply
+        // an operation to each element
+        let mut operate =
+            |lhs: Var,
+             rhs: Var,
+             op: Box<dyn Fn(u64, u64, usize, usize, usize) -> (Vec<R1csConstraint>, u64)>|
+             -> Var {
+                let mut new_var = Var {
+                    index: self.var_index,
+                    location: VarLocation::Constraint,
+                    dimensions: lhs.dimensions.clone(),
+                    value: vec![],
+                };
+                self.var_index += lhs.value.len();
+                for x in 0..lhs.value.len() {
+                    // will generate constraints and output value
+                    let (constraints, val) = (*op)(
+                        lhs.value[x],
+                        rhs.value[x],
+                        lhs.index + x,
+                        rhs.index + x,
+                        new_var.index + x,
+                    );
+                    new_var.value.push(val);
+                    for c in constraints {
+                        self.constraints.push(c);
                     }
-                    if self.vars.contains_key(&name) {
-                        log::error!("variable already defined: {name}");
-                    }
-                    // returns a variable index
-                    let v = self.eval(expr);
-                    self.vars.insert(name, v);
                 }
-                AstNode::Const(name, expr) => {}
-                _ => {
-                    log::error!(&format!("ast node not supported for r1cs: {:?}", v));
-                }
+                new_var
+            };
+        // TODO: better field math
+        match op {
+            Op::Add => {
+                let add = |a: u64,
+                           b: u64,
+                           ai: usize,
+                           bi: usize,
+                           oi: usize|
+                 -> (Vec<R1csConstraint>, u64) {
+                    let x = (u128::try_from(a).unwrap() + u128::try_from(b).unwrap())
+                        % u128::try_from(self.prime).unwrap();
+                    // (1*lv + 1*rv) * (1*1) - (1*new_var) = 0
+                    // lv + rv - new_var = 0
+                    (
+                        vec![R1csConstraint {
+                            a: vec![(1, ai), (1, bi)],
+                            b: vec![(1, 0)],
+                            c: vec![(1, oi)],
+                        }],
+                        u64::try_from(x).unwrap(),
+                    )
+                };
+                operate(lv, rv, Box::new(add))
+            }
+            Op::Mul => {
+                let mul = |a: u64,
+                           b: u64,
+                           ai: usize,
+                           bi: usize,
+                           oi: usize|
+                 -> (Vec<R1csConstraint>, u64) {
+                    let x = (u128::try_from(a).unwrap() * u128::try_from(b).unwrap())
+                        % u128::try_from(self.prime).unwrap();
+                    // (1*lv) * (1*rv) - (1*new_var) = 0
+                    // lv * rv - new_var = 0
+                    (
+                        vec![R1csConstraint {
+                            a: vec![(1, ai)],
+                            b: vec![(1, bi)],
+                            c: vec![(1, oi)],
+                        }],
+                        u64::try_from(x).unwrap(),
+                    )
+                };
+                operate(lv, rv, Box::new(mul))
+            }
+            Op::Sub => {
+                let sub = |a: u64,
+                           b: u64,
+                           ai: usize,
+                           bi: usize,
+                           oi: usize|
+                 -> (Vec<R1csConstraint>, u64) {
+                    let x = (u128::try_from(self.prime - 1).unwrap() + u128::try_from(a).unwrap()
+                        - u128::try_from(b).unwrap())
+                        % u128::try_from(self.prime).unwrap();
+                    // (1*lv + -1*rv) * (1*1) - (1*new_var) = 0
+                    // lv + -1*rv - new_var = 0
+                    (
+                        vec![R1csConstraint {
+                            a: vec![(1, ai), (self.prime - 1, bi)],
+                            b: vec![(1, 0)],
+                            c: vec![(1, oi)],
+                        }],
+                        u64::try_from(x).unwrap(),
+                    )
+                };
+                operate(lv, rv, Box::new(sub))
+            }
+            Op::Inv => {
+                // (1/rhs) * lhs
+                // first invert the rhs and store in a variable
+                let inv = |_: u64,
+                           b: u64,
+                           _: usize,
+                           bi: usize,
+                           oi: usize|
+                 -> (Vec<R1csConstraint>, u64) {
+                    let b_inv = crate::r1cs::inv::inv(b, self.prime);
+                    // first: constrain rhs_inv
+                    // (1*rhs) * (1*rhs_inv) - (1*1) = 0
+                    // rhs * rhs_inv - 1 = 0
+                    (
+                        vec![R1csConstraint {
+                            a: vec![(1, bi)],
+                            b: vec![(1, oi)],
+                            c: vec![(1, 0)],
+                        }],
+                        u64::try_from(b_inv).unwrap(),
+                    )
+                };
+                let rv_inv = operate(rv.clone(), rv.clone(), Box::new(inv));
+                // then multiple rv_inv by the lhs
+                let mul = |a: u64,
+                           b: u64,
+                           ai: usize,
+                           bi: usize,
+                           oi: usize|
+                 -> (Vec<R1csConstraint>, u64) {
+                    let x = (u128::try_from(a).unwrap() * u128::try_from(b).unwrap())
+                        % u128::try_from(self.prime).unwrap();
+                    // (1*lv) * (1*rv) - (1*new_var) = 0
+                    // lv * rv - new_var = 0
+                    (
+                        vec![R1csConstraint {
+                            a: vec![(1, ai)],
+                            b: vec![(1, bi)],
+                            c: vec![(1, oi)],
+                        }],
+                        u64::try_from(x).unwrap(),
+                    )
+                };
+                operate(lv, rv_inv, Box::new(mul))
             }
         }
     }

--- a/stdlib/mod.ash
+++ b/stdlib/mod.ash
@@ -6,10 +6,10 @@
 # non-field operations like floored division to be used
 #
 # for tasm execution an assembly implementation would be provided
-#const quotient = in \ b
-const quotient = 0
+const quotient = in \ b
 const remainder = a - quotient * b
 
+# todo: implement lt in r1cs
 assert_eq(lt(remainder, quotient), 1)
 assert_eq(lt(quotient, quotient), 1)
 

--- a/stdlib/u32/lower32.ash
+++ b/stdlib/u32/lower32.ash
@@ -1,7 +1,0 @@
-(v)
-
-# given a number return the number % 2^32
-
-const m = 2*32
-
-return mod(v, m)

--- a/test-vectors/r1cs_test.ash
+++ b/test-vectors/r1cs_test.ash
@@ -1,0 +1,6 @@
+let x = 99
+let y = 1
+
+let z = x + y
+
+#assert_eq(z, 1)

--- a/test-vectors/r1cs_test.ash
+++ b/test-vectors/r1cs_test.ash
@@ -1,6 +1,11 @@
 let x = 99
 let y = 1
 
-let z = x + y
+let z0 = x + y
+let z1 = x * y
+let z2 = x - y
+let z3 = x / y
+
+let _ = z1 * z2
 
 #assert_eq(z, 1)


### PR DESCRIPTION
Adds compile support for the `r1cs` target. e.g. `cargo run -- r1cs_test -t r1cs -i ./test-vectors -v`

Defines an r1cs format with 1 constraint per line like the following:

```
[ (1, 0) (5, 1) ] [ (1, 0) ] [ (0, 0) ] # spaces added for readability
[(1, 0)(2, 1)][(1, 0)][(0, 0)]
```

Each line represents a single constraint. Each bracket represents a set of variables with coefficients. `(coefficient, variable_index)`. Variables are analogous to wires/signals in circom. Each bracket is combined using addition. e.g. `[(2, 0)(3, 1)]` = `2*vars[0] + 3*vars[1]`.

Each line is combined like `bracket[0] * bracket[1] - bracket[2]`. So taking the example:
`[ (1, 0) (5, 1) ] [ (1, 0) ] [ (0, 0) ]` = `(1*vars[0] + 5*vars[1]) * (1*vars[0]) - 0*vars[0] = 0`

An example ashlang program compiles as follows:
```sh
let x = 99
let y = 1

let z0 = x + y
let z1 = x * y
let z2 = x - y
let z3 = x / y

let _ = z1 * z2

```
```
[(1,1)][(1,0)][(99,0)]
[(1,2)][(1,0)][(1,0)]
[(1,1)(1,2)][(1,0)][(1,3)]
[(1,1)][(1,2)][(1,4)]
[(1,1)(18446744069414584320,2)][(1,0)][(1,5)]
[(1,2)][(1,6)][(1,0)]
[(1,1)][(1,6)][(1,7)]
[(1,4)][(1,5)][(1,8)]
```

Note that the above program is unrealistic because signals are rarely assigned constant values. Instead each signal would be an input or a result of a previous signal (like in the `z` assignment). Literal values will likely be used in `const` assignments instead, indicating they don't need to be constrained, but can only be used as coefficients or for flow control.