### PR TITLE
Spartan compatibility changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,9 +348,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.14"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d2eb3cd3d1bf4529e31c215ee6f93ec5a3d536d9f578f93d9d33ee19562932"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "shlex",
 ]
@@ -452,9 +452,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cpufeatures"
@@ -1266,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "scalarff"
-version = "0.0.7"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f0e84063df8dd2619f683f6cf0d52e7b8a401c864c80bc5a356d4cef5a65b9"
+checksum = "c535e59693a8ee592a4f0359de8bd6918c82e40a715b58ad73fcdac3a18d4a7d"
 dependencies = [
  "anyhow",
  "ark-bn254",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ pest_derive = "2.7.11"
 triton-vm = "=0.41.0"
 
 # math
-scalarff = "0.0.7"
+scalarff = "0.1.1"

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -193,12 +193,20 @@ Path 2: {:?}",
         }
     }
 
+    pub fn compile_str(&mut self, entry_src: &str, target: &str) -> String {
+        let parser = AshParser::parse(entry_src, "entry");
+        self.compile_parser(parser, target)
+    }
+
     // start at the entry file
     // parse it and determine what other files are needed
     // repeat until all files have been parsed
     pub fn compile(&mut self, entry_fn_name: &str, target: &str) -> String {
         let parser = AshParser::parse(&self.parse_fn(entry_fn_name).0, entry_fn_name);
+        self.compile_parser(parser, target)
+    }
 
+    fn compile_parser(&mut self, parser: AshParser, target: &str) -> String {
         // tracks total number of includes for a fn in all sources
         let mut included_fn: HashMap<String, u64> = parser.fn_names.clone();
         // step 1: build ast for all functions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,5 @@ pub mod log;
 pub mod parser;
 pub mod r1cs;
 pub mod tasm;
+
+pub use cli::Config;


### PR DESCRIPTION
Export compiler config from `lib` target. Allow compiler to accept a string source entrypoint.