### PR TITLE
feat: print a path of function

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -310,7 +310,11 @@ Path 2: {:?}",
                 // step 2: add functions to file
                 for (fn_call, fn_asm) in &self.state.compiled_fn {
                     asm.push("\n".to_string());
-                    asm.push(format!("{}: // {}", fn_call.typed_name(), self.state.fn_to_path.get(&fn_call.name).unwrap()));
+                    asm.push(format!(
+                        "{}: // {}",
+                        fn_call.typed_name(),
+                        self.state.fn_to_path.get(&fn_call.name).unwrap()
+                    ));
                     asm.append(&mut fn_asm.clone());
                 }
 
@@ -341,7 +345,6 @@ Path 2: {:?}",
 
                 if self.print_asm {
                     // prints the assembly
-
                     for l in &final_asm {
                         println!("{}", l);
                     }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -310,7 +310,7 @@ Path 2: {:?}",
                 // step 2: add functions to file
                 for (fn_call, fn_asm) in &self.state.compiled_fn {
                     asm.push("\n".to_string());
-                    asm.push(format!("{}:", fn_call.typed_name()));
+                    asm.push(format!("{}: // {}", fn_call.typed_name(), self.state.fn_to_path.get(&fn_call.name).unwrap()));
                     asm.append(&mut fn_asm.clone());
                 }
 
@@ -343,14 +343,6 @@ Path 2: {:?}",
                     // prints the assembly
 
                     for l in &final_asm {
-                        // prints the function's path as well if it's a function call
-                        if l.contains("____") {
-                            let mut fn_name = l.split("____").next().unwrap();
-                            fn_name = fn_name.strip_prefix("call ").unwrap_or(fn_name);
-                            println!("{} ({})", l, self.state.fn_to_path.get(fn_name).unwrap());
-                            continue;
-                        }
-
                         println!("{}", l);
                     }
                 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -28,6 +28,8 @@ pub struct CompilerState<T: FieldElement> {
     pub block_counter: usize,
     pub block_fn_asm: Vec<Vec<String>>,
     pub fn_to_r1cs_parser: HashMap<String, R1csParser<T>>,
+    pub path_to_fn: HashMap<Utf8PathBuf, String>,
+    pub fn_to_path: HashMap<String, Utf8PathBuf>,
     pub messages: Vec<String>,
 }
 
@@ -49,14 +51,14 @@ impl<T: FieldElement> CompilerState<T> {
             block_counter: 0,
             block_fn_asm: vec![],
             fn_to_r1cs_parser: HashMap::new(),
+            path_to_fn: HashMap::new(),
+            fn_to_path: HashMap::new(),
             messages: vec![],
         }
     }
 }
 
 pub struct Compiler<T: FieldElement> {
-    path_to_fn: HashMap<Utf8PathBuf, String>,
-    fn_to_path: HashMap<String, Utf8PathBuf>,
     pub print_asm: bool,
     state: CompilerState<T>,
     extensions: Vec<String>,
@@ -75,8 +77,6 @@ pub struct Compiler<T: FieldElement> {
 impl<T: FieldElement> Compiler<T> {
     pub fn new(config: &Config) -> Result<Self> {
         let mut compiler = Compiler {
-            path_to_fn: HashMap::new(),
-            fn_to_path: HashMap::new(),
             print_asm: false,
             state: CompilerState::new(),
             extensions: config.extension_priorities.clone(),
@@ -121,13 +121,14 @@ impl<T: FieldElement> Compiler<T> {
                 anyhow::bail!("Failed to parse file stem for include path: {:?}", path)
             }
             let name_str = name_str.unwrap().to_string();
-            if self.fn_to_path.contains_key(&name_str) {
+            if self.state.fn_to_path.contains_key(&name_str) {
                 // check if another file exists at the same path with a different
                 // extension
                 //
                 // if so prefer the higher index file
 
                 let existing_path = self
+                    .state
                     .fn_to_path
                     .get(&name_str)
                     .unwrap()
@@ -135,7 +136,7 @@ impl<T: FieldElement> Compiler<T> {
                 if existing_path.parent().is_none() {
                     anyhow::bail!(
                         "Failed to canonicalize path: {:?}",
-                        self.fn_to_path.get(&name_str).unwrap()
+                        self.state.fn_to_path.get(&name_str).unwrap()
                     )
                 }
                 if existing_path.parent() != path.canonicalize_utf8()?.parent() {
@@ -144,7 +145,7 @@ impl<T: FieldElement> Compiler<T> {
 Path 1: {:?}
 Path 2: {:?}",
                         &path,
-                        self.fn_to_path.get(&name_str).unwrap()
+                        self.state.fn_to_path.get(&name_str).unwrap()
                     ));
                 }
                 let existing_extension = existing_path.extension().unwrap();
@@ -156,13 +157,13 @@ Path 2: {:?}",
                 let current_index = self.extensions.iter().position(|x| *x == *ext).unwrap();
                 if current_index > existing_index {
                     // we'll prefer the higher indexed impl
-                    self.fn_to_path.insert(name_str.clone(), path.clone());
-                    self.path_to_fn.insert(path.clone(), name_str);
+                    self.state.fn_to_path.insert(name_str.clone(), path.clone());
+                    self.state.path_to_fn.insert(path.clone(), name_str);
                 }
                 return Ok(());
             }
-            self.fn_to_path.insert(name_str.clone(), path.clone());
-            self.path_to_fn.insert(path.clone(), name_str);
+            self.state.fn_to_path.insert(name_str.clone(), path.clone());
+            self.state.path_to_fn.insert(path.clone(), name_str);
         } else if metadata.is_dir() {
             let files = fs::read_dir(path)
                 .unwrap_or_else(|_| panic!("Failed to read directory: {:?}", &path));
@@ -179,7 +180,7 @@ Path 2: {:?}",
     // loads, parses, and returns an ashlang function by name
     // returns the function as an ast
     pub fn parse_fn(&self, fn_name: &str) -> Result<(String, String)> {
-        if let Some(file_path) = self.fn_to_path.get(fn_name) {
+        if let Some(file_path) = self.state.fn_to_path.get(fn_name) {
             if let Some(ext) = file_path.extension() {
                 let unparsed_file = std::fs::read_to_string(file_path)
                     .unwrap_or_else(|_| panic!("Failed to read source file: {:?}", file_path));
@@ -340,7 +341,16 @@ Path 2: {:?}",
 
                 if self.print_asm {
                     // prints the assembly
+
                     for l in &final_asm {
+                        // prints the function's path as well if it's a function call
+                        if l.contains("____") {
+                            let mut fn_name = l.split("____").next().unwrap();
+                            fn_name = fn_name.strip_prefix("call ").unwrap_or(fn_name);
+                            println!("{} ({})", l, self.state.fn_to_path.get(fn_name).unwrap());
+                            continue;
+                        }
+
                         println!("{}", l);
                     }
                 }

--- a/src/r1cs/vm.rs
+++ b/src/r1cs/vm.rs
@@ -121,7 +121,7 @@ impl<'a, T: FieldElement> VM<'a, T> {
                     let fn_source_path = self.compiler_state.fn_to_path.get(&self.name).unwrap();
                     self.compiler_state.messages.insert(
                         0,
-                        format!("return call in {}() ({})", self.name, fn_source_path),
+                        format!("return call in {})", fn_source_path),
                     );
                     if self.return_val.is_some() {
                         return log::error!(

--- a/src/r1cs/vm.rs
+++ b/src/r1cs/vm.rs
@@ -121,7 +121,7 @@ impl<'a, T: FieldElement> VM<'a, T> {
                     let fn_source_path = self.compiler_state.fn_to_path.get(&self.name).unwrap();
                     self.compiler_state.messages.insert(
                         0,
-                        format!("return call in {})", fn_source_path),
+                        format!("return call in {}", fn_source_path),
                     );
                     if self.return_val.is_some() {
                         return log::error!(

--- a/src/r1cs/vm.rs
+++ b/src/r1cs/vm.rs
@@ -119,10 +119,9 @@ impl<'a, T: FieldElement> VM<'a, T> {
                 }
                 AstNode::Rtrn(expr) => {
                     let fn_source_path = self.compiler_state.fn_to_path.get(&self.name).unwrap();
-                    self.compiler_state.messages.insert(
-                        0,
-                        format!("return call in {}", fn_source_path),
-                    );
+                    self.compiler_state
+                        .messages
+                        .insert(0, format!("return call in {}", fn_source_path));
                     if self.return_val.is_some() {
                         return log::error!(
                             "return value already set",

--- a/src/r1cs/vm.rs
+++ b/src/r1cs/vm.rs
@@ -118,9 +118,11 @@ impl<'a, T: FieldElement> VM<'a, T> {
                     }
                 }
                 AstNode::Rtrn(expr) => {
-                    self.compiler_state
-                        .messages
-                        .insert(0, format!("return call in {}", self.name));
+                    let fn_source_path = self.compiler_state.fn_to_path.get(&self.name).unwrap();
+                    self.compiler_state.messages.insert(
+                        0,
+                        format!("return call in {}() ({})", self.name, fn_source_path),
+                    );
                     if self.return_val.is_some() {
                         return log::error!(
                             "return value already set",
@@ -275,7 +277,10 @@ impl<'a, T: FieldElement> VM<'a, T> {
             }
             Expr::FnCall(name, vars) => {
                 // TODO: break this into separate functions
-                self.compiler_state.messages.insert(0, format!("{name}()"));
+                let path = self.compiler_state.fn_to_path.get(name).unwrap();
+                self.compiler_state
+                    .messages
+                    .insert(0, format!("{}() ({})", name, path));
                 let args: Vec<Var<T>> = vars.iter().map(|v| self.eval(v)).collect::<Result<_>>()?;
                 // look for an ar1cs implementation first
                 if let Some(v) = self.compiler_state.fn_to_r1cs_parser.get(name) {


### PR DESCRIPTION
Fixes #46

tasm:
```
...
call lower32_____s (stdlib/u32/lower32.tasm)
swap 2
pop 1
dup 2
dup 2
call xor_____s_s (stdlib/u32/xor.tasm)
push 7
call shlc_____s_s (stdlib/u32/shlc.tasm)
swap 3
pop 1
dup 3
push 0
...
```

r1cs:
```
cargo run --release -- r1cs_readme --target r1cs --include ./test-vectors --include stdlib --print '--scalar field to execute in' foi
   Compiling ashlang v0.1.0 (/Users/daehyun/workspace/ashlang/ashlang)
    Finished `release` profile [optimized] target(s) in 7.49s
     Running `target/release/ashlang r1cs_readme --target r1cs --include ./test-vectors --include stdlib --print '--scalar field to execute in' foi`
x1 = (1*one) * (99*one)                 # scalar literal (99) to signal index 0 (member of vector)
x2 = (1*one) * (43*one)                 # scalar literal (43) to signal index 0 (member of vector)
x3 = (1*x1) * (1*x2)                    # let v
x4 = (1*one) / (1*x2)                   # let v
x5 = (1*x1) * (1*x4)                    # let v
x6 = (1*x3 + 1*x5) * (1*one)            # let v
x7 = (1*x6 + 18446744069414584311*one) * (1*one) # let v
x8 = (9008875010644336127*one) + (0*one) # assert_eq() (stdlib/assert_eq.ar1cs)
x9 = (1*x7) * (1*x7)                    # let v2
x10 = (1*x9) * (1*x9)                   # let v4
x11 = (1*x10) * (1*x7)                  # return call in pow5() (stdlib/pow5.ash)
x12 = (1*x7) * (1*x7)                   # return call in pow5() (stdlib/pow5.ash)
x13 = (1*x12) * (1*x7)                  # return call in pow5() (stdlib/pow5.ash)
x14 = (1*x13) * (1*x7)                  # return call in pow5() (stdlib/pow5.ash)
x15 = (1*x14) * (1*x7)                  # return call in pow5() (stdlib/pow5.ash)
x16 = (1*one) * (21941893*one)          # scalar literal (00000000000021941893) to signal index 0 (member of vector)
x17 = (2*one) radix (1*x16)             # b is the square root of a
x18 = (899715509682497048*one) + (0*one) # assert_eq() (stdlib/assert_eq.ar1cs)
x19 = (1*x17) * (1*x17)                 # assert_eq() (stdlib/assert_eq.ar1cs)
x20 = (0*one + 18446744069414584320*x17) * (1*one) # let high_root
x21 = (17547028559732087273*one) + (0*one) # assert_eq() (stdlib/assert_eq.ar1cs)
x22 = (1*x20) * (1*x20)                 # assert_eq() (stdlib/assert_eq.ar1cs)
x23 = (0*one + 18446744069414584320*x16) * (1*one) # assert_eq() (stdlib/assert_eq.ar1cs)
x24 = (1*x17) * (1*x20)                 # assert_eq() (stdlib/assert_eq.ar1cs)
0 = (18446744069414584320*one) * (18446744069414584320*one) - (1*one) # field safety constraint
0 = (1*x1) * (1*one) - (99*one)         # scalar literal (99) to signal index (0) (member of vector)
0 = (1*x2) * (1*one) - (43*one)         # scalar literal (43) to signal index (0) (member of vector)
0 = (1*x1) * (1*x2) - (1*x3)            # multiplication between 1 and 2 into 3
0 = (1*x2) * (1*x4) - (1*one)           # inversion of 2 into 4 (1/2)
0 = (1*x1) * (1*x4) - (1*x5)            # multiplication of 1 and 4 into 5 (2/2)
0 = (1*x3 + 1*x5) * (1*one) - (1*x6)    # addition between 3 and 5 into 6
0 = (10*one + 1*x7) * (1*one) - (1*x6)  # subtraction between 6 and (10) into 7
0 = (1*x8) * (1*one) - (9008875010644336127*one) # assigning literal (09008875010644336127) to signal 8
0 = (1*x7 + 0*one) * (1*one) - (1*x8)   # assert equality
0 = (1*x7) * (1*x7) - (1*x9)            # multiplication between 7 and 7 into 9
0 = (1*x9) * (1*x9) - (1*x10)           # multiplication between 9 and 9 into 10
0 = (1*x10) * (1*x7) - (1*x11)          # multiplication between 10 and 7 into 11
0 = (1*x7) * (1*x7) - (1*x12)           # multiplication between 7 and 7 into 12
0 = (1*x12) * (1*x7) - (1*x13)          # multiplication between 12 and 7 into 13
0 = (1*x13) * (1*x7) - (1*x14)          # multiplication between 13 and 7 into 14
0 = (1*x14) * (1*x7) - (1*x15)          # multiplication between 14 and 7 into 15
0 = (1*x11 + 0*one) * (1*one) - (1*x15) # assert equality
0 = (1*x16) * (1*one) - (21941893*one)  # scalar literal (00000000000021941893) to signal index (0) (member of vector)
0 = (1*x17) * (1*x17) - (1*x16)         # assert that a = b*b
0 = (1*x18) * (1*one) - (899715509682497048*one) # assigning literal (00899715509682497048) to signal 18
0 = (1*x17 + 0*one) * (1*one) - (1*x18) # assert equality
0 = (1*x17) * (1*x17) - (1*x19)         # multiplication between 17 and 17 into 19
0 = (1*x16 + 0*one) * (1*one) - (1*x19) # assert equality
0 = (1*x17 + 1*x20) * (1*one) - (0*one) # subtraction between (0) and 17 into 20
0 = (1*x21) * (1*one) - (17547028559732087273*one) # assigning literal (17547028559732087273) to signal 21
0 = (1*x20 + 0*one) * (1*one) - (1*x21) # assert equality
0 = (1*x20) * (1*x20) - (1*x22)         # multiplication between 20 and 20 into 22
0 = (1*x16 + 0*one) * (1*one) - (1*x22) # assert equality
0 = (1*x16 + 1*x23) * (1*one) - (0*one) # subtraction between (0) and 16 into 23
0 = (1*x17) * (1*x20) - (1*x24)         # multiplication between 17 and 20 into 24
0 = (1*x23 + 0*one) * (1*one) - (1*x24) # assert equality

R1CS: built and validated witness ✅
No outputs were generated
```