### PR TITLE
new prover api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ashlang"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "camino",

--- a/ashlang/Cargo.toml
+++ b/ashlang/Cargo.toml
@@ -40,7 +40,7 @@ pest_derive = "2.7.11"
 triton-vm = { version = "=0.41.0", optional = true }
 
 # math
-#scalarff = { path = "../scalarff" }
+#scalarff = { path = "../../scalarff" }
 scalarff = "0.5.1"
 
 # spartan

--- a/ashlang/Cargo.toml
+++ b/ashlang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ashlang"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 authors = ["Chance Hudson <PSE>"]
 description = "A language for zero knowledge proofs"

--- a/ashlang/src/provers/ashlang_prover.rs
+++ b/ashlang/src/provers/ashlang_prover.rs
@@ -9,6 +9,10 @@ use crate::cli::Config;
 /// The generic argument indicates the type of the proof that
 /// the prover builds.
 pub trait AshlangProver<T> {
+    /// Generate a proof by compiling source files into an IR
     fn prove(config: &Config) -> Result<T>;
+    /// Generate a proof from an existing IR
+    fn prove_ir(ir: &str, public_inputs: Vec<String>, secret_inputs: Vec<String>) -> Result<T>;
+    /// Verify a proof
     fn verify(proof: T) -> Result<bool>;
 }

--- a/ring-math/Cargo.toml
+++ b/ring-math/Cargo.toml
@@ -14,3 +14,4 @@ license = "MIT OR Apache-2.0"
 anyhow = "1.0.89"
 rand = "0.8.5"
 scalarff = { version = "0.5.1", features = ["oxfoi", "alt_bn128", "curve25519", "random"] }
+#scalarff = { path = "../../scalarff", features = ["oxfoi", "alt_bn128", "curve25519", "random"] }


### PR DESCRIPTION
Adds `prove_ir` function for proving `ar1cs` and `tasm` code